### PR TITLE
feature(selter-cli): take from config path as well

### DIFF
--- a/identity-wallet/setler-cli/src/lib/wallet/gatekeep.js
+++ b/identity-wallet/setler-cli/src/lib/wallet/gatekeep.js
@@ -68,6 +68,7 @@ export const gatekeep = async (
   context.poolEndpoint =
     context.flags.poolEndpoint ||
     process.env.SETLER_POOL_ENDPOINT ||
+    context.config.auth?.SETLER_POOL_ENDPOINT ||
     DEFAULTS.POOL_ENDPOINT;
 
   if (context.flags.verbose) {


### PR DESCRIPTION
We should be able to configure the setler with:

* command line
* ENV VARS
* config 

and then fall back to a generic default.

